### PR TITLE
Update to trigger CI build on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -133,8 +133,8 @@ deploy:
   tag: $(APPVEYOR_REPO_TAG_NAME)
   auth_token:
     secure: Cpy9Gq2fafl7Q8Wqpamv89vv8bOQHjFsjZyYFmBCWK3GR5jH8QTITyEhiBJ3DDNQ
-  draft: false
-  prerelease: true
+  draft: true
+  prerelease: false
   force_update: true
   on:
     branch: master                 # release from master branch only

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cityhub",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "MIT",
   "author": {
     "name": "City Chain Foundation",


### PR DESCRIPTION
- Set the release to draft, not allowing the CI builds to publish a build.