### PR TITLE
Add History for block explorer #57

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -4,7 +4,7 @@ parameters:
   name: ''
   queue: ''
   platform: ''
-  daemon: '0.0.21' # Version of the daemon to download, upgrade when newer is released.
+  daemon: '0.0.22' # Version of the daemon to download, upgrade when newer is released.
   arch: 'x64' # Only overriden by 32-bit Windows
   configuration: 'Release' # Only do Debug if specified
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cityhub",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "license": "MIT",
   "author": {
     "name": "City Chain Foundation",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { LoadComponent } from './components/load/load.component';
 import { NetworkComponent } from './components/network/network.component';
 import { MerchantsComponent } from './components/merchants/merchants.component';
 import { UpdateComponent } from './components/update/update.component';
+import { HistoryComponent } from './components/history/history.component';
 
 const routes: Routes = [
     {
@@ -91,6 +92,10 @@ const routes: Routes = [
     {
         path: 'account',
         loadChildren: './components/account/account.module#AccountModule'
+    },
+    {
+        path: 'history',
+        loadChildren: './components/history/history.module#HistoryModule'
     },
     {
         path: '**',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { MerchantsModule } from './components/merchants/merchants.module';
 import { environment } from '../environments/environment';
 import { ChainService } from './services/chain.service';
 import { UpdateModule } from './components/update/update.module';
+import { HistoryModule } from './components/history/history.module';
 
 @NgModule({
   declarations: [
@@ -55,6 +56,7 @@ import { UpdateModule } from './components/update/update.module';
     UpdateModule,
     MerchantsModule,
     DetailsModule,
+    HistoryModule,
     AppRoutingModule,
   ],
   exports: [

--- a/src/app/components/history/block/block.component.html
+++ b/src/app/components/history/block/block.component.html
@@ -1,0 +1,124 @@
+<div class="content">
+
+    <div *ngIf="!block">Loading...</div>
+
+    <div class="content-cards" *ngIf="block">
+
+        <mat-card class="block-details-card">
+            <h2>Info</h2>
+
+            <div class="block-details">
+                <div class="block-details-label">Number (Height)</div>
+                <div class="block-details-value">{{block.height}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Time</div>
+                <div class="block-details-value">{{block.time * 1000 | date:'dd-MM-yyyy HH:mm'}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Transaction count</div>
+                <div class="block-details-value">{{block.transactions.length}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Input count</div>
+                <div class="block-details-value">{{block.inputs}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Output count</div>
+                <div class="block-details-value">{{block.outputs}}</div>
+            </div>
+        </mat-card>
+
+        <mat-card class="block-details-card" *ngIf="block">
+            <h2>Details</h2>
+
+            <div class="block-details">
+                <div class="block-details-label">Size</div>
+                <div class="block-details-value">{{block.size}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Version</div>
+                <div class="block-details-value">{{block.version}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Bits</div>
+                <div class="block-details-value">{{block.bits}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Difficulty</div>
+                <div class="block-details-value">{{block.difficulty}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Nonce</div>
+                <div class="block-details-value">{{block.nonce}}</div>
+            </div>
+            <div class="block-details">
+                <div class="block-details-label">Merkle root</div>
+                <div class="block-details-value" title="{{block.merkleRoot}}">
+                    <span class="ellipsis" style="max-width: 100px;">{{ block.merkleRoot }}</span>
+                </div>
+                <!--  ng-class="{true:'ellipsis', false:''}[block.merkleRoot.length>=10]" -->
+                <!-- <div class="block-details-value"><span ng-class="{'ellipsis': block.merkleRoot.length > 10}">{{ block.merkleRoot | limitTo: 10 }}{{block.merkleRoot.length > 10 ? '...' : ''}}</span></div> -->
+            </div>
+        </mat-card>
+
+        <mat-card class="block-navigate-card" *ngIf="block">
+            <button (click)="increment()" mat-icon-button>
+                <mat-icon>expand_less</mat-icon>
+            </button>
+            <button (click)="decrement()" *ngIf="block.height !== 1" mat-icon-button>
+                <mat-icon>expand_more</mat-icon>
+            </button>
+        </mat-card>
+    </div>
+
+    <mat-tab-group mat-stretch-tabs *ngIf="block" class="history-block-stretched-tabs mat-elevation-z4">
+        <mat-tab label="Transactions ({{block.transactions.length}})">
+            <div class="tab-pane">
+
+                <table class="transactions-table mat-elevation-z8" mat-table [dataSource]="dataSource">
+
+                    <ng-container matColumnDef="txid">
+                        <th mat-header-cell *matHeaderCellDef> Id </th>
+                        <td mat-cell *matCellDef="let transaction">
+                            <a routerLink="/history/transaction/{{transaction.txid}}">{{transaction.txid}}</a>
+                        </td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="output">
+                        <th mat-header-cell *matHeaderCellDef> Output </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.output}}  {{coinUnit}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="inputs">
+                        <th mat-header-cell *matHeaderCellDef> Inputs </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.vin.length}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="outputs">
+                        <th mat-header-cell *matHeaderCellDef> Outputs </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.vout.length}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="size">
+                        <th mat-header-cell *matHeaderCellDef> Size </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.size}}</td>
+                    </ng-container>
+
+                    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                </table>
+
+                <mat-paginator pageSize="10" showFirstLastButtons></mat-paginator>
+
+            </div>
+        </mat-tab>
+        <mat-tab label="Raw Block">
+            <div class="tab-pane">
+                <em>
+                    {{blockJson}}
+                </em>
+            </div>
+        </mat-tab>
+    </mat-tab-group>
+</div>

--- a/src/app/components/history/block/block.component.scss
+++ b/src/app/components/history/block/block.component.scss
@@ -1,0 +1,51 @@
+.block
+{
+    .content-cards
+    {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .block-details
+    {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .block-details-label
+    {
+        width: 120px;
+        margin-right: 20px;
+    }
+
+    .block-details-value
+    {
+    }
+
+    .block-details-card
+    {
+        margin-right: 20px;
+        margin-bottom: 20px;
+        flex: 1 1 auto;
+        width: 50%;
+    }
+
+    .block-navigate-card
+    {
+        //margin-right: 20px;
+        margin-bottom: 20px;
+        padding: 2px;
+        //flex: 1 1 auto;
+        width: 50px;
+    }
+
+    .tab-pane
+    {
+        padding: 10px;
+    }
+
+    .transactions-table {
+        width: 100%;
+    }
+
+}

--- a/src/app/components/history/block/block.component.ts
+++ b/src/app/components/history/block/block.component.ts
@@ -1,0 +1,165 @@
+import { Component, ViewEncapsulation, HostBinding, OnInit, OnDestroy, ViewChild, HostListener } from '@angular/core';
+import { Subscription, throwError } from 'rxjs';
+import { MatSnackBar, MatTableDataSource, MatPaginator } from '@angular/material';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { map, catchError } from 'rxjs/operators';
+import { ApplicationStateService } from '../../../services/application-state.service';
+import { DetailsService } from '../../../services/details.service';
+import { ApiService } from '../../../services/api.service';
+import { GlobalService } from '../../../services/global.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { PAGE_DOWN, PAGE_UP, HOME, END } from '@angular/cdk/keycodes';
+import { WalletInfo } from '../../../classes/wallet-info';
+
+@Component({
+    selector: 'app-history-block',
+    templateUrl: './block.component.html',
+    styleUrls: ['./block.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class BlockHistoryComponent implements OnInit, OnDestroy {
+    @HostBinding('class.block') hostClass = true;
+
+    copied = false;
+    coinUnit: string;
+    confirmations: number;
+    block: any;
+    blockJson: string;
+    displayedColumns: string[] = ['txid', 'output', 'inputs', 'outputs', 'size'];
+    dataSource = new MatTableDataSource<any>();
+    @ViewChild(MatPaginator) paginator: MatPaginator;
+    @HostListener('window:keyup', ['$event'])
+    keyEvent(event: KeyboardEvent) {
+        console.log(event);
+
+        if (event.keyCode === PAGE_UP) {
+            this.increment();
+        }
+
+        if (event.keyCode === PAGE_DOWN) {
+            this.decrement();
+        }
+
+        if (event.keyCode === END) {
+            this.openLatest();
+        }
+
+        if (event.keyCode === HOME) {
+            this.open(1);
+        }
+    }
+
+    constructor(
+        private http: HttpClient,
+        public appState: ApplicationStateService,
+        private detailsService: DetailsService,
+        private apiService: ApiService,
+        public snackBar: MatSnackBar,
+        private route: ActivatedRoute,
+        private router: Router,
+        private globalService: GlobalService
+    ) {
+        this.appState.pageMode = true;
+    }
+
+    openLatest() {
+        let walletInfo = new WalletInfo(this.globalService.getWalletName());
+        this.apiService.getGeneralInfoOnceTyped(walletInfo).subscribe(info => {
+            this.open(info.lastBlockSyncedHeight);
+        });
+    }
+
+    open(height: number) {
+        this.router.navigateByUrl('/history/block/' + height);
+    }
+
+    increment() {
+        this.router.navigateByUrl('/history/block/' + (this.block.height + 1));
+    }
+
+    decrement() {
+        this.router.navigateByUrl('/history/block/' + (this.block.height - 1));
+    }
+
+    private handleError(error: HttpErrorResponse | any) {
+        if (error.error instanceof ErrorEvent) {
+            // A client-side or network error occurred. Handle it accordingly.
+            console.error('An error occurred:', error.error.message);
+        } else {
+            // The backend returned an unsuccessful response code.
+            // The response body may contain clues as to what went wrong,
+            console.error(
+                `Backend returned code ${error.status}, ` +
+                `body was: ${error.errors}`);
+        }
+        // return an observable with a user-facing error message
+        return throwError('Something bad happened; please try again later.');
+    };
+
+    ngOnInit() {
+        this.getBlock();
+        this.coinUnit = this.globalService.getCoinUnit();
+        this.dataSource.paginator = this.paginator;
+    }
+
+    ngOnDestroy() {
+
+    }
+
+    getBlock() {
+        this.route.params.subscribe(params => {
+
+            // TODO: Get API port by current active network configuration.
+            var url = 'http://localhost:24335/api/blocks/' + params.id + '?api-version=2.0';
+
+            this.http
+                .get<any[]>(url)
+                .pipe(catchError(this.handleError))
+                .pipe(map(data => data)).subscribe(
+                    item => {
+                        this.block = item;
+                        this.blockJson = JSON.stringify(item);
+
+                        console.log('BLOCK', item);
+
+                        var inputs = 0;
+                        var outputs = 0;
+
+                        this.block.transactions.forEach(tx => {
+
+                            var out = 0;
+
+                            if (tx.vout != null) {
+                                outputs += tx.vout.length;
+                            }
+
+                            if (tx.vin != null) {
+                                inputs += tx.vin.length;
+                            }
+
+                            tx.vout.forEach(script => {
+
+                                if (script.value) {
+                                    out += script.value;
+                                }
+
+                            });
+
+                            tx.output = out;
+
+                        });
+
+                        this.block.inputs = inputs;
+                        this.block.outputs = outputs;
+
+                        this.dataSource.data = this.block.transactions;
+                    }
+                );
+        });
+    }
+
+    public onCopiedClick() {
+        let snackBarRef = this.snackBar.open('The transaction ID has been copied to your clipboard.', null, { duration: 3000 });
+        return false;
+    }
+}

--- a/src/app/components/history/history-routing.module.ts
+++ b/src/app/components/history/history-routing.module.ts
@@ -1,0 +1,42 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { HistoryComponent } from './history.component';
+import { BlockHistoryComponent } from './block/block.component';
+import { TransactionHistoryComponent } from './transaction/transaction.component';
+import { AuthenticatedUserGuard } from '../../modules/authentication/guards/authenticated-user.guard';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: HistoryComponent,
+    canActivate: [AuthenticatedUserGuard],
+    data: {
+      title: 'History'
+    }
+  },
+  {
+    path: 'block/:id',
+    component: BlockHistoryComponent,
+    canActivate: [AuthenticatedUserGuard],
+    data: {
+      title: 'Block',
+      prefix: 'History'
+  },
+  },
+  {
+    path: 'transaction/:id',
+    component: TransactionHistoryComponent,
+    canActivate: [AuthenticatedUserGuard],
+    data: {
+      title: 'Transaction',
+      prefix: 'History'
+  },
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+
+export class HistoryRoutingModule { }

--- a/src/app/components/history/history.component.html
+++ b/src/app/components/history/history.component.html
@@ -1,0 +1,100 @@
+<div class="content">
+
+    <div *ngIf="undefined === blocks">Loading...</div>
+
+    <mat-card class="history-search-card">
+        <mat-form-field class="history-form-field">
+            <input matInput type="text" placeholder="Enter block number or block hash and press search." (keyup.enter)="search($event)" [(ngModel)]="searchInput">
+            <button mat-button *ngIf="value" matSuffix mat-icon-button aria-label="Clear" (click)="value=''">
+                <mat-icon>close</mat-icon>
+            </button>
+        </mat-form-field>
+        <button class="history-search-button" (click)="search()" [disabled]="searchInput.length == 0" mat-stroked-button>Search</button>
+        <button class="history-search-button" (click)="refresh()" [disabled]="loading" mat-stroked-button>Refresh</button>
+    </mat-card>
+
+    <mat-tab-group mat-stretch-tabs class="history-block-stretched-tabs mat-elevation-z4">
+        <mat-tab label="Blocks">
+            <div class="tab-pane">
+
+                <table class="history-table mat-elevation-z8" mat-table [dataSource]="dataSource">
+
+                    <ng-container matColumnDef="height">
+                        <th mat-header-cell *matHeaderCellDef> Number </th>
+                        <td mat-cell *matCellDef="let block">
+                            <a routerLink="/block/{{block.hash}}">{{block.height}}</a>
+                        </td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="hash">
+                        <th mat-header-cell *matHeaderCellDef> Hash </th>
+
+                        <td mat-cell *matCellDef="let block">
+                            {{block.hash}}
+                        </td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="time">
+                        <th mat-header-cell *matHeaderCellDef> Date </th>
+                        <td mat-cell *matCellDef="let block">{{block.time * 1000 | date:'dd-MM-yyyy HH:mm'}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="transactions">
+                        <th mat-header-cell *matHeaderCellDef> Transactions </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let block">
+                            {{block.transactions.length}}
+                        </td>
+                    </ng-container>
+
+                    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                </table>
+
+                <mat-paginator pageSize="10" showFirstLastButtons></mat-paginator>
+
+                <div [innerHTML]="selectedContent"></div>
+            </div>
+        </mat-tab>
+        <mat-tab label="Transactions">
+            <div class="tab-pane">
+
+                <table class="transactions-table mat-elevation-z8" mat-table [dataSource]="dataSourceTransactions">
+
+                    <ng-container matColumnDef="txid">
+                        <th mat-header-cell *matHeaderCellDef> Transaction Id </th>
+                        <td mat-cell *matCellDef="let transaction">
+                            <a routerLink="/history/transaction/{{transaction.txid}}">{{transaction.txid}}</a>
+                        </td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="output">
+                        <th mat-header-cell *matHeaderCellDef> Output </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.output}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="inputs">
+                        <th mat-header-cell *matHeaderCellDef> Inputs </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.vin.length}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="outputs">
+                        <th mat-header-cell *matHeaderCellDef> Outputs </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.vout.length}}</td>
+                    </ng-container>
+
+                    <ng-container matColumnDef="size">
+                        <th mat-header-cell *matHeaderCellDef> Size </th>
+                        <td mat-cell class="history-table-right" *matCellDef="let transaction">{{transaction.size}}</td>
+                    </ng-container>
+
+                    <tr mat-header-row *matHeaderRowDef="displayedColumnsTransactions"></tr>
+                    <tr mat-row *matRowDef="let row; columns: displayedColumnsTransactions;"></tr>
+                </table>
+
+                <em class="info-label">Only last 10 transactions is supported. Paging will be available in a future update.</em>
+                <!-- <mat-paginator pageSize="10" showFirstLastButtons></mat-paginator> -->
+
+            </div>
+        </mat-tab>
+    </mat-tab-group>
+</div>

--- a/src/app/components/history/history.component.scss
+++ b/src/app/components/history/history.component.scss
@@ -1,0 +1,33 @@
+.history
+{
+    .history-table {
+        width: 100%;
+    }
+
+    .transactions-table {
+        width: 100%;
+    }
+
+    .history-table-right {
+        text-align: right;
+    }
+
+    .history-form-field
+    {
+        width: calc(100% - 220px);
+    }
+
+    .history-search-button {
+        width: 90px;
+        margin-left: 20px;
+    }
+
+    .history-search-card {
+        margin-bottom: 10px;
+    }
+
+    .info-label {
+        display: inline-block;
+        padding: 10px;
+    }
+}

--- a/src/app/components/history/history.component.ts
+++ b/src/app/components/history/history.component.ts
@@ -1,0 +1,126 @@
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, HostBinding, OnInit, OnDestroy, Input, ViewChild } from '@angular/core';
+import { DetailsService } from '../../services/details.service';
+import { ApiService } from '../../services/api.service';
+import { GlobalService } from '../../services/global.service';
+import { Subscription } from 'rxjs';
+import { TransactionInfo } from '../../classes/transaction-info';
+import { WalletInfo } from '../../classes/wallet-info';
+import { MatSnackBar, MatTableDataSource, MatPaginator } from '@angular/material';
+import { ApplicationStateService } from '../../services/application-state.service';
+import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
+import { Router } from '@angular/router';
+
+@Component({
+    selector: 'app-history',
+    templateUrl: './history.component.html',
+    styleUrls: ['./history.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class HistoryComponent implements OnInit, OnDestroy {
+    @HostBinding('class.history') hostClass = true;
+
+    public loading = false;
+    public searchInput = '';
+    public copied = false;
+    public coinUnit: string;
+    public confirmations: number;
+
+    private generalWalletInfoSubscription: Subscription;
+    private lastBlockSyncedHeight: number;
+    private blocks: any = [];
+    private transactions: any = [];
+
+    displayedColumns: string[] = ['height', 'hash', 'time', 'transactions'];
+    public dataSource = new MatTableDataSource<any>();
+    @ViewChild(MatPaginator) paginator: MatPaginator;
+
+    displayedColumnsTransactions: string[] = ['txid', 'output', 'outputs', 'inputs', 'size'];
+    public dataSourceTransactions = new MatTableDataSource<any>();
+    @ViewChild(MatPaginator) paginatorTransactions: MatPaginator;
+
+    constructor(
+        private http: HttpClient,
+        public appState: ApplicationStateService,
+        private detailsService: DetailsService,
+        private apiService: ApiService,
+        private router: Router,
+        public snackBar: MatSnackBar,
+        private globalService: GlobalService
+    ) {
+        this.appState.pageMode = false;
+    }
+
+    get transaction(): TransactionInfo {
+        return this.detailsService.item;
+    }
+
+    ngOnInit() {
+        this.coinUnit = this.globalService.getCoinUnit();
+        this.dataSource.paginator = this.paginator;
+        this.refresh();
+    }
+
+    refresh() {
+        this.getLatestBlocks();
+        this.getLatestTransactions();
+    }
+
+    search() {
+        this.router.navigateByUrl('/history/block/' + this.searchInput);
+    }
+
+    ngOnDestroy() {
+       
+    }
+
+    public onCopiedClick() {
+        let snackBarRef = this.snackBar.open('The transaction ID has been copied to your clipboard.', null, { duration: 3000 });
+        return false;
+    }
+    
+    private getLatestTransactions() {
+        var url = 'http://localhost:24335/api/transactions?api-version=2.0';
+
+        this.http
+        .get<any[]>(url)
+        .pipe(map(data => data)).subscribe(
+            items => {
+                // Calculate the in and out, this should in the future be added to the API perhaps to easier API consumption?
+                items.forEach(tx => {
+                    var out = 0;
+
+                    tx.vout.forEach(script => {
+
+                        if (script.value) {
+                            out += script.value;
+                        }
+
+                    });
+
+                    tx.output = out;
+
+                });
+
+                this.transactions = items;
+                this.dataSourceTransactions.data = items;
+            }
+        );
+    }
+
+    private getLatestBlocks() {
+        var url = 'http://localhost:24335/api/blocks?api-version=2.0';
+
+        this.loading = true;
+
+        this.http
+            .get<any[]>(url)
+            .pipe(map(data => data)).subscribe(
+                items => {
+                    this.blocks = items;
+                    this.dataSource.data = items;
+                    this.loading = false;
+                }
+            );
+    }
+}

--- a/src/app/components/history/history.module.ts
+++ b/src/app/components/history/history.module.ts
@@ -1,0 +1,38 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MaterialModule } from '../../material.module';
+import { AppSharedModule } from '../../shared/app-shared.module';
+import { ClipboardModule } from 'ngx-clipboard';
+import { HttpClientModule } from '@angular/common/http';
+import { HistoryComponent } from './history.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BlockHistoryComponent } from './block/block.component';
+import { TransactionHistoryComponent } from './transaction/transaction.component';
+import { HistoryRoutingModule } from './history-routing.module';
+
+@NgModule({
+    imports: [
+        HttpClientModule,
+        CommonModule,
+        RouterModule,
+        FormsModule,
+        ReactiveFormsModule,
+        AppSharedModule,
+        ClipboardModule,
+        MaterialModule,
+        HistoryRoutingModule
+    ],
+    declarations: [
+        HistoryComponent,
+        BlockHistoryComponent,
+        TransactionHistoryComponent
+    ],
+    exports: [
+        HistoryComponent,
+        BlockHistoryComponent,
+        TransactionHistoryComponent
+    ],
+})
+export class HistoryModule {
+}

--- a/src/app/components/history/transaction/transaction.component.html
+++ b/src/app/components/history/transaction/transaction.component.html
@@ -1,0 +1,36 @@
+<div class="content">
+
+    <div *ngIf="!transaction">Loading...</div>
+
+    <div class="content-cards" *ngIf="transaction">
+
+        <mat-card class="transaction-details-card">
+            <h2>Info</h2>
+
+            <div class="transaction-details">
+                <div class="transaction-details-label">Output</div>
+                <div class="transaction-details-value">{{transaction.output}} {{coinUnit}}</div>
+            </div>
+        </mat-card>
+
+        <mat-card class="transaction-details-card" *ngIf="transaction">
+            <h2>Details</h2>
+
+        </mat-card>
+    </div>
+
+    <mat-tab-group mat-stretch-tabs *ngIf="transaction" class="history-transaction-stretched-tabs mat-elevation-z4">
+        <mat-tab label="Inputs / Outputs">
+            <div class="tab-pane">
+                <em>Not supported. Will be available in a future update.</em>
+            </div>
+        </mat-tab>
+        <mat-tab label="Raw Transaction">
+            <div class="tab-pane">
+                <em>
+                    {{transactionJson}}
+                </em>
+            </div>
+        </mat-tab>
+    </mat-tab-group>
+</div>

--- a/src/app/components/history/transaction/transaction.component.scss
+++ b/src/app/components/history/transaction/transaction.component.scss
@@ -1,0 +1,49 @@
+.transaction
+{
+    .content-cards
+    {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .transaction-details
+    {
+        display: flex;
+        flex-direction: row;
+    }
+
+    .transaction-details-label
+    {
+        width: 120px;
+        margin-right: 20px;
+    }
+
+    .transaction-details-value
+    {
+    }
+
+    .transaction-details-card
+    {
+        margin-right: 20px;
+        margin-bottom: 20px;
+        flex: 1 1 auto;
+        width: 50%;
+    }
+
+    .transaction-navigate-card
+    {
+        margin-bottom: 20px;
+        padding: 2px;
+        width: 50px;
+    }
+
+    .tab-pane
+    {
+        padding: 10px;
+    }
+
+    .transactions-table {
+        width: 100%;
+    }
+
+}

--- a/src/app/components/history/transaction/transaction.component.ts
+++ b/src/app/components/history/transaction/transaction.component.ts
@@ -1,0 +1,85 @@
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, HostBinding, OnInit, OnDestroy, Input, ViewChild } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { MatSnackBar, MatTableDataSource, MatPaginator } from '@angular/material';
+import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
+import { ApplicationStateService } from '../../../services/application-state.service';
+import { DetailsService } from '../../../services/details.service';
+import { ApiService } from '../../../services/api.service';
+import { GlobalService } from '../../../services/global.service';
+import { TransactionInfo } from '../../../classes/transaction-info';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+    selector: 'app-history-transaction',
+    templateUrl: './transaction.component.html',
+    styleUrls: ['./transaction.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class TransactionHistoryComponent implements OnInit, OnDestroy {
+    @HostBinding('class.transaction') hostClass = true;
+
+    copied = false;
+    coinUnit: string;
+    confirmations: number;
+    transactionJson: string;
+    transaction: any;
+
+    private generalWalletInfoSubscription: Subscription;
+
+    constructor(
+        public appState: ApplicationStateService,
+        public snackBar: MatSnackBar,
+        private detailsService: DetailsService,
+        private apiService: ApiService,
+        private http: HttpClient,
+        private route: ActivatedRoute,
+        private globalService: GlobalService
+    ) {
+        this.appState.pageMode = true;
+    }
+
+    ngOnInit() {
+        this.route.params.subscribe(params => {
+            this.getTransaction(params.id);
+        });
+
+        this.coinUnit = this.globalService.getCoinUnit();
+    }
+
+    ngOnDestroy() {
+        
+    }
+
+    public onCopiedClick() {
+        let snackBarRef = this.snackBar.open('The transaction ID has been copied to your clipboard.', null, { duration: 3000 });
+        return false;
+    }
+
+    private getTransaction(id: string) {
+        var url = 'http://localhost:24335/api/transactions/' + id + '?api-version=2.0';
+
+        this.http
+            .get<any>(url)
+            .pipe(map(data => data)).subscribe(
+                item => {
+                    this.transaction = item;
+                    this.transactionJson = JSON.stringify(item);
+
+                    var out = 0;
+
+                    if (this.transaction.vout != null) {
+                        this.transaction.vout.forEach(script => {
+
+                            if (script.value) {
+                                out += script.value;
+                            }
+
+                        });
+                    }
+
+                    this.transaction.output = out;
+                }
+            );
+    }
+}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -30,11 +30,12 @@ export class LoginComponent implements OnInit {
 
     constructor(
         private readonly cd: ChangeDetectorRef,
-        private authService: AuthenticationService, private router: Router,
-        public appState: ApplicationStateService,
+        private authService: AuthenticationService, 
+        private router: Router,
         private globalService: GlobalService,
         private wallet: WalletService,
-        private apiService: ApiService) {
+        private apiService: ApiService,
+        public appState: ApplicationStateService) {
 
     }
 

--- a/src/app/components/root/root.component.html
+++ b/src/app/components/root/root.component.html
@@ -60,6 +60,11 @@
           <!-- <p *ngIf="showFiller" mat-line> Latest </p> -->
         </mat-list-item>
 
+        <mat-list-item routerLinkActive="main-menu-active" routerLink="/history">
+          <mat-icon mat-list-icon>history</mat-icon>
+          <h4 *ngIf="showFiller" mat-line>History</h4>
+        </mat-list-item>
+
         <mat-list-item routerLinkActive="main-menu-active" routerLink="/merchants">
           <mat-icon mat-list-icon>map</mat-icon>
           <h4 *ngIf="showFiller" mat-line>Merchants</h4>

--- a/src/app/components/root/root.component.ts
+++ b/src/app/components/root/root.component.ts
@@ -75,7 +75,7 @@ export class RootComponent implements OnInit, OnDestroy {
     console.log('Expanded:', localStorage.getItem('Menu:Expanded'));
 
     this.loadFiller();
-    
+
     this.isAuthenticated = authService.isAuthenticated();
 
     if (this.electronService.remote) {
@@ -162,8 +162,11 @@ export class RootComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    // We'll check for updates in the startup of the app.
-    this.checkForUpdates();
+
+    setTimeout(() => {
+      // We'll check for updates in the startup of the app.
+      this.checkForUpdates();
+    }, 10000);
 
     if (this.router.url !== '/load') {
       this.router.navigateByUrl('/load');

--- a/src/app/components/wallet/wallet.component.html
+++ b/src/app/components/wallet/wallet.component.html
@@ -153,19 +153,13 @@
                 </div>
             </div>
         </mat-tab>
-        <mat-tab label="Received">
+        <!-- <mat-tab label="Received">
             <div class="tab-pane">
-                <!-- <div *ngFor="let usedAddress of usedAddresses" class="tab-pane-line">
-                        <code class="d-inline-block">{{ usedAddress }}</code>
-                    </div> -->
             </div>
         </mat-tab>
         <mat-tab label="Sent">
             <div class="tab-pane">
-                <!-- <div *ngFor="let changeAddress of changeAddresses" class="tab-pane-line">
-                        <code class="d-inline-block">{{ changeAddress }}</code>
-                    </div> -->
             </div>
-        </mat-tab>
+        </mat-tab> -->
     </mat-tab-group>
 </div>

--- a/src/app/components/wallet/wallet.component.ts
+++ b/src/app/components/wallet/wallet.component.ts
@@ -52,7 +52,11 @@ export class WalletComponent implements OnInit {
 
     ngOnInit() {
         this.dataSource.paginator = this.paginator;
-        this.dataSource.data = this.wallet.transactionArray;
+
+        // "Cannot read property 'length' of undefined" error when setting to empty value.
+        if (this.wallet.transactionArray != null) {
+            this.dataSource.data = this.wallet.transactionArray;
+        }
     }
 
     public stopStaking() {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -159,6 +159,18 @@ export class ApiService {
       .pipe(map((response: Response) => response));
   }
 
+   /**
+   * Get general wallet info from the API once.
+   */
+  getGeneralInfoOnceTyped(data: WalletInfo): Observable<GeneralInfo> {
+    let params: URLSearchParams = new URLSearchParams();
+    params.set('Name', data.walletName);
+
+    return this.http
+      .get(this.stratisApiUrl + '/wallet/general-info', new RequestOptions({ headers: this.headers, search: params }))
+      .pipe(map((response: Response) => <GeneralInfo>(response.json())));
+  }
+
   /**
    * Get general wallet info from the API.
    */

--- a/src/app/services/wallet.service.ts
+++ b/src/app/services/wallet.service.ts
@@ -108,6 +108,9 @@ export class WalletService {
                 response => {
                     if (response.status >= 200 && response.status < 400) {
                         let balanceResponse = response.json();
+
+                        console.log('RESPONSE: ', balanceResponse);
+
                         //TO DO - add account feature instead of using first entry in array
                         this.confirmedBalance = balanceResponse.balances[0].amountConfirmed;
                         this.unconfirmedBalance = balanceResponse.balances[0].amountUnconfirmed;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -151,6 +151,13 @@ body {
 	user-select: none;
   }
 
+span.ellipsis {
+    display:inline-block;
+    white-space: nowrap;
+    overflow:hidden;
+    text-overflow: ellipsis;
+}
+
 // ::-webkit-scrollbar-track {
 // 	background-color: orange;
 // }


### PR DESCRIPTION
- Add History menu item that shows a block explorer that retrieve data from local full node.
- This explorer gives users full privacy, no third parties can see what blocks and transactions they are looking at.
- Needs more work, there are features missing, especially on transaction details.