### PR TITLE
Disable trigger, rename yaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,13 @@
 # City Hub - Continuous Integration Setup for VSTS
 
-trigger:
-  branches:
-    include:
-    - master
-    - feature/*
-    - bug/*
-    exclude:
-    - v* #Exclude verions tags
+#trigger:
+#  branches:
+#    include:
+#    - master
+#    - feature/*
+#    - bug/*
+#    exclude:
+#    - v* #Exclude verions tags
 
 phases:
 - template: build.yml


### PR DESCRIPTION
- Appears that trigger override on Azure DevOps, creates dual builds when trigger is defined in YAML file.