### PR TITLE
Update version numbers

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -4,7 +4,7 @@ parameters:
   name: ''
   queue: ''
   platform: ''
-  daemon: '0.0.26' # Version of the daemon to download, upgrade when newer is released.
+  daemon: '1.0.1' # Version of the daemon to download, upgrade when newer is released.
   arch: 'x64' # Only overriden by 32-bit Windows
   configuration: 'Release' # Only do Debug if specified
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cityhub",
-    "version": "0.0.32",
+    "version": "1.0.1",
     "license": "MIT",
     "author": {
         "name": "City Chain Foundation",

--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -5,7 +5,7 @@
         <mat-card-header>
             <mat-card-title>Version {{appState.version}}
                 <br>Network: {{appState.network}} ({{appState.mode}})</mat-card-title>
-            <mat-card-subtitle>City Hub is your hub into the City Chain, and other supported blockchains. City Hub is currently only available in PREVIEW release, use with caution.
+            <mat-card-subtitle>City Hub is your hub into the City Chain, and other supported blockchains. As always, use with caution.
             </mat-card-subtitle>
         </mat-card-header>
         <mat-card-content>

--- a/src/app/components/about/changes/changes.component.html
+++ b/src/app/components/about/changes/changes.component.html
@@ -1,129 +1,14 @@
 <div class="content">
     <h1 class="mat-h1" *ngIf="appState.handset">{{appState.appTitle$ | async}}</h1>
 
-    <h3 class="mat-h3">September 13, 2018 (v0.0.30)</h3>
+    <h3 class="mat-h3">October 4, 2018 (v1.0.1)</h3>
 
     <ul>
         <li>
-            <strong>Improved</strong> the sentences and explanations on account create and recovery.
+            <strong>TESTNET</strong> launch of City Chain and City Hub.
         </li>
-        <li><strong>Fix</strong> issues with API that was modified in new City Chain release.</li>
-        <li><strong>Hides</strong> the unconfirmed amount in wallet if zero.</li>
-    </ul>
-
-    <h3 class="mat-h3">September 13, 2018 (v0.0.29)</h3>
-
-    <ul>
-        <li>
-            <strong>Improved</strong> dashboard layout.
-        </li>
-        <li><strong>Fix</strong> issues with API that was modified in new City Chain release.</li>
-    </ul>
-
-    <h3 class="mat-h3">August 23, 2018 (v0.0.24)</h3>
-
-    <ul>
-        <li>
-            <strong>Improved</strong> network status retrieval, and wallet status.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 19, 2018 (v0.0.23)</h3>
-
-    <ul>
-        <li>
-            <strong>Wallet Mode</strong> is a new option in settings. Can be set to Single-Address-Mode, and the default is Multi-Address-Mode. Can be used to operate a wallet that has a single public address.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 19, 2018 (v0.0.22)</h3>
-
-    <ul>
-        <li>
-            <strong>History</strong> was added to the menu. History is a block explorer that allows you to look into all blocks and the transactions within the blocks.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 13, 2018 (v0.0.21)</h3>
-
-    <ul>
-        <li>
-            <strong>City Chain</strong> was updated to latest release.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 11, 2018 (v0.0.20)</h3>
-
-    <ul>
-        <li>
-            <strong>Mac and Linux</strong> releases are now available.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 9, 2018 (v0.0.19)</h3>
-
-    <ul>
-        <li>
-            <strong>Account Restore</strong> now has a loading indicator while processing the restore. Previously the UI did not
-            change until after account restored.
-        </li>
-        <li>
-            <strong>Download progress indicator</strong> on the network page has been moved to the bottom of the grids.
-        </li>
-        <li>
-            <strong>The blockchain selection</strong> on the top-left icon has been temporarily disabled until a future release with
-            support for Bitcoin and other blockchains.
-        </li>
-        <li>
-            <strong>Removed options</strong> on the settings page, until they are implemented.</li>
-        <li><strong>Scroll to top</strong> on navigation. Changing pages now scrolls the view to the top.</li>
-        <li><strong>Menu expanded on</strong> first launch, and remembered next time user restarts City Hub (open or minimized).</li>
-    </ul>
-
-    <h3 class="mat-h3">August 5, 2018 (v0.0.18)</h3>
-
-    <ul>
-        <li>
-            <strong>Auto-update</strong> is now working as expected and with custom UX that allows users to decide when to download
-            an update.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 2, 2018 (v0.0.3)</h3>
-
-    <ul>
-        <li>
-            <strong>Auto-account selection on login screen.</strong> If no previous account has been used, the first is selected.
-            This makes it more obvious what the user should do, after they have created or restored an account. It also reduces
-            user tasks by one.
-        </li>
-        <li>
-            <strong>Auto-network selection on setup screen.</strong> During the preview release testing, only TESTNET and FULL MODE
-            is supported, so these values are auto-selected on the initial setup screen. When the MAINNET is released, the
-            setup screen will be skipped and the two options will be picked by default.</li>
-        <li>
-            <strong>Bug
-                <a href="https://github.com/CityChainFoundation/city-hub/issues/34" target="_blank">#34</a>:</strong>
-            Fixed issue with network status sometimes not rendering properly.
-        </li>
-    </ul>
-
-    <h3 class="mat-h3">August 1, 2018 (v0.0.2)</h3>
-
-    <ul>
-        <li>
-            <strong>Updated node seeds</strong>
-        </li>
-        <li>First attempt at auto-update feature.</li>
-    </ul>
-
-    <h3 class="mat-h3">August 1, 2018 (v0.0.1)</h3>
-
-    <ul>
-        <li>
-            <strong>Initial preview release for TESTNET.</strong> This release is not to be expected to be used by average users,
-            but hardcore testers and developers.
-        </li>
+        <li>Previous release history has been removed. This is the first official release of City Hub.</li>
+        <li>It is <strong>only TESTNET</strong> which is supported in this release.</li>
     </ul>
 
 </div>

--- a/src/app/components/load/load.component.ts
+++ b/src/app/components/load/load.component.ts
@@ -52,10 +52,10 @@ export class LoadComponent implements OnDestroy {
 
         this.networks = [
             // { id: 'main', name: 'Main' }, // Disabled in beta release.
+            // { id: 'citymain', name: 'City Chain' },
             { id: 'citytest', name: 'City Chain (Test)' },
-            { id: 'citymain', name: 'City Chain' },
-            { id: 'stratistest', name: 'Stratis (Test)' },
-            { id: 'stratismain', name: 'Stratis' },
+            // { id: 'stratistest', name: 'Stratis (Test)' },
+            // { id: 'stratismain', name: 'Stratis' },
             // { id: 'regtest', name: 'RegTest' } // Disabled in beta release.
         ];
 


### PR DESCRIPTION
- Truncate the existing change log, new users does not need to know preview release changes.
- Update version numbers for Release 1.